### PR TITLE
Future-proof {up,down}stream merges

### DIFF
--- a/test/abcdefghijklmnopqrstuvwxyz.spec.js
+++ b/test/abcdefghijklmnopqrstuvwxyz.spec.js
@@ -7,4 +7,7 @@ describe('`abcdefghijklmnopqrstuvwxyz`', () => {
   it('is \'abcdefghijklmnopqrstuvwxyz\'', () => {
     assert.deepStrictEqual(abcdefghijklmnopqrstuvwxyz, 'abcdefghijklmnopqrstuvwxyz')
   })
+  it('has a length of 26 characters', () => {
+    assert.deepStrictEqual(abcdefghijklmnopqrstuvwxyz.length, 26)
+  })
 })


### PR DESCRIPTION
Ensure tests differentiate qntm/abcdefghijklmnopqrstuvwxyz from XertroV/abcdefghijklmnopqrstuvxyz.

This ensures that future {up,down}stream merges between abcdefghijklmnopqrstuvwxyz  and abcdefghijklmnopqrstuvxyz will not accidentally change the character set, thus assisting the longevity and reliability of both packages.